### PR TITLE
fix: use hugo.toml https baseURL in Pages build

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -47,8 +47,7 @@ jobs:
         run: |
           hugo \
             --gc \
-            --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
+            --minify
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

The deploy workflow built with `--baseURL "${{ steps.pages.outputs.base_url }}/"`. Because **Enforce HTTPS** is not yet enabled for the custom domain, that output resolves to `http://henry40408.com/`, which leaked into the generated `canonical` and `og:url` tags.

## Change

- Drop the `--baseURL` override in the Hugo build step so the build uses the `https://henry40408.com/` value already configured in `hugo.toml`.

## Verification

- Local `hugo --gc --minify` produces `og:url = https://henry40408.com/`
- No `http://henry40408` URLs remain in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)