### PR TITLE
chore: add Dependabot for GitHub Actions with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Wait 7 days after a release before opening an update PR, so that
+    # freshly-published (potentially compromised) versions have time to be
+    # caught and yanked first.
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Summary

Add a Dependabot configuration that keeps the workflow's GitHub Actions up to date.

- **Ecosystem:** `github-actions` (directory `/`)
- **Schedule:** weekly
- **Cooldown:** `default-days: 7` — Dependabot waits 7 days after a release before opening an update PR, so freshly-published (potentially compromised) versions have time to be caught and yanked first
- **Commit prefix:** `chore` to match the repo's conventional-commit style

Works hand-in-hand with the SHA-pinned actions (#3): Dependabot updates both the commit SHA and the `# vX.Y.Z` comment in place.

## Notes

- `github-actions` supports `default-days` but not the `semver-*-days` cooldown sub-fields (those are SemVer-manager only), so a single `default-days` is the correct knob here.
- Config validated as well-formed YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)