### PR TITLE
chore: group Dependabot github-actions updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
       default-days: 7
     commit-message:
       prefix: "chore"
+    # Bundle all github-actions updates into a single PR per run.
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Add a `groups` block to the `github-actions` ecosystem so all action version updates land in a **single PR per run** instead of one PR per action.

```yaml
groups:
  github-actions:
    patterns:
      - "*"
```

Supersedes the four individual update PRs (#5–#8); once merged, those will be closed and Dependabot will re-open them as one grouped PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)