### PR TITLE
ci: add PR build check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.163.3
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb \
+            https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo \
+            --gc \
+            --minify


### PR DESCRIPTION
## Summary

Add a lightweight `CI` workflow that verifies the site builds on every pull request, closing the gap where the existing deploy workflow only runs on push to `main` (so PRs currently have no checks).

- **Trigger:** `pull_request` + `workflow_dispatch`
- **Job:** install Hugo (pinned `0.163.3` extended, matching deploy), checkout with `submodules: recursive`, run `hugo --gc --minify`
- **Build-only** — no deployment
- `actions/checkout` pinned to the same SHA (`v7.0.0`) used by the deploy workflow; Dependabot's `github-actions` group already keeps it updated

## Verification

- Local `hugo --gc --minify` builds cleanly (12 pages, no errors)
- This PR itself will exercise the new workflow — it should show a green **CI / build** check

🤖 Generated with [Claude Code](https://claude.com/claude-code)