### PR TITLE
Fix deprecated .Site.LanguageCode and set locale to zh-TW

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -7,7 +7,7 @@ theme = 'hugo-bearblog'
 # Basic metadata configuration for your blog.
 title = "henry40408"
 author = "Heng-Yi Wu"
-locale = "en-US"
+locale = "zh-TW"
 
 # Generate a nice robots.txt for SEO
 enableRobotsTXT = true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="{{ with .Site.Language.Locale }}{{ . }}{{ else }}en-US{{ end }}">
+
+<head>
+  <meta http-equiv="X-Clacks-Overhead" content="GNU Terry Pratchett" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  {{- partial "favicon.html" . -}}
+  <title>{{- block "title" . }}{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{- end }}</title>
+
+  {{- partial "seo_tags.html" . -}}
+  <meta name="referrer" content="no-referrer-when-downgrade" />
+
+  {{ with .OutputFormats.Get "rss" -}}
+  {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  {{ end -}}
+
+  {{- partial "style.html" . -}}
+
+  <!-- A partial to be overwritten by the user.
+  Simply place a custom_head.html into
+  your local /layouts/partials-directory -->
+  {{- partial "custom_head.html" . -}}
+</head>
+
+<body>
+  <header>
+    {{- partial "header.html" . -}}
+  </header>
+  <main>
+    {{- block "main" . }}{{- end }}
+  </main>
+  <footer>
+    {{- partial "footer.html" . -}}
+  </footer>
+
+  <!-- A partial to be overwritten by the user.
+  Simply place a custom_body.html into
+  your local /layouts/partials-directory -->
+  {{- partial "custom_body.html" . -}}
+</body>
+
+</html>


### PR DESCRIPTION
## Summary

- Override the theme's `baseof.html` locally to replace `.Site.LanguageCode` (deprecated in Hugo v0.158.0) with `.Site.Language.Locale`, which fixes the build-time deprecation warning.
- Set the site locale to `zh-TW` (Traditional Chinese) in `hugo.toml`.

## Verification

- `hugo --gc` builds with no deprecation warnings or errors.
- `public/index.html` renders `<html lang="zh-TW">`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)