### PR TITLE
feat: open external links in a new tab

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,4 @@
+{{- $siteHost := (urls.Parse site.BaseURL).Host -}}
+{{- $linkHost := (urls.Parse .Destination).Host -}}
+{{- $external := and $linkHost (ne $linkHost $siteHost) -}}
+<a href="{{ .Destination | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ if $external }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
## Summary

Add a Markdown link render hook so that links pointing to an external host open in a new tab/window.

## Details

- New file: `layouts/_default/_markup/render-link.html`
- A link is treated as **external** when its parsed host is non-empty and differs from the site host (`henry40408.com`).
- External links get `target="_blank"` and `rel="noopener noreferrer"` (security/privacy best practice for `_blank`).
- Internal absolute links, relative links (`/blog/`) and in-page anchors (`#heading`) are left untouched.
- Only affects Markdown content links; hardcoded theme partials (header/footer/nav) are unchanged.

## Verification

Built locally with the CI-pinned Hugo version (0.163.3 extended). In the `Rust 狂熱` post (28 external links), all external links received `target="_blank" rel="noopener noreferrer"`, while internal links did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)